### PR TITLE
Add directories and templates for gitlab

### DIFF
--- a/.gitlab/issue_templates/issue.md
+++ b/.gitlab/issue_templates/issue.md
@@ -1,0 +1,32 @@
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+* Version used:
+* Environment name and version (e.g. Chrome 39, node.js 5.4):
+* Operating System and version (desktop or mobile):
+* Link to your project:

--- a/.gitlab/merge_request_templates/feature.md
+++ b/.gitlab/merge_request_templates/feature.md
@@ -1,0 +1,36 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Related Issue
+<!--- This project only accepts pull requests related to open issues -->
+<!--- If suggesting a new feature or change, please discuss it in an issue first -->
+<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
+<!--- Please link to the issue here: -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Screenshots (if appropriate):
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have read the **CONTRIBUTING** document.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For the sake of the example here is how you can use this project template
 as a basis for your own repository:
 
 ```bash
-git clone https://github.com/mnapoli/project-template.git my-project
+git clone https://github.com/vanoix/repository-template.git my-project
 cd my-project
 # Remove the git repository metadata
 rm -rf .git/
@@ -58,6 +58,11 @@ For *this* project, I choose […drumroll…] the [Do What the Fuck You Want to 
 ## Support
 
 See the [SUPPORT](SUPPORT.md) file. (Don't forget to change default email/slack/...)
+
+## Templates
+
+You should review templates for issue/(pull|merge) requests for github and gitlab. Feel free to
+update them and, if you work with gitlab, add others templates.
 
 ## Credits
 


### PR DESCRIPTION
Add issue/merge_request template for gitlab

## Description
Gitlab handle many templates for issue/merge requests in [two different directories](https://gitlab.com/help/user/project/description_templates.md).

## Related Issue
Related issue: #2 

## Motivation and Context
Needed because Github is not our lord.

## How Has This Been Tested?
Tested on gitlab.com

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/204451/30454801-de0d74a2-999d-11e7-9f86-e71344a811a7.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
